### PR TITLE
Refactor for extensibility and maintainablility

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -11,6 +11,7 @@ module.exports =
       default: "br, hr, img, input, link, meta, area, base, col, command, embed, keygen, param, source, track, wbr"
 
   activate: (state) ->
+    # Register config change handler to update the empty tags list
     atom.config.observe "less-than-slash.emptyTags", (value) =>
       @emptyTags = (tag.toLowerCase() for tag in value.split(/\s*[\s,|]+\s*/))
 
@@ -18,127 +19,85 @@ module.exports =
       buffer = editor.getBuffer()
       buffer.onDidChange (event) =>
         if event.newText == "/"
+          # Ignore it if its right at the start of a line
           if event.newRange.start.column > 0
-            checkText = buffer.getTextInRange [[event.newRange.start.row, event.newRange.start.column - 2], [event.newRange.end.row, event.newRange.end.column]]
-            # Check if we just typed a closing tag </
-            # We need to substr relative to the length of the checkText cause
-            # it could be only 2 chars long if we type </ at the start of a line
-            if checkText.substr(checkText.length - 2, checkText.length) == "</"
-              text = buffer.getTextInRange [[0, 0], event.oldRange.end]
-              stack = @findTagsIn text
-              if stack.length
-                tag = stack.pop()
-                buffer.insert event.newRange.end, "#{tag.element}>"
-            # Check if we just typed a handlebars closing tag {{/
-            else if checkText == '{{/'
-              text = buffer.getTextInRange [[0, 0], event.oldRange.end]
-              stack = @findTagsIn text
-              if stack.length
-                tag = stack.pop()
-                buffer.insert event.newRange.end, "#{tag.element}"
+            getCheckText = ->
+              buffer.getTextInRange([
+                [event.newRange.start.row, 0],
+                event.newRange.end
+              ])
+            getText = ->
+              buffer.getTextInRange [[0, 0], event.oldRange.end]
+            if textToInsert = @onSlash getCheckText, getText
+              buffer.insert event.newRange.end, textToInsert
 
-  findTagsIn: (text) ->
-    stack = []
-    while text
-      if text[0...4] is "<!--"
-        if (_text = @handleComment text)?
-          text = _text
-        else
-          stack = []
-          text = text[4..]
-      else if text[0...9] is "<![CDATA["
-        if (_text = @handleCDATA text)?
-          text = _text
-        else
-          stack = []
-          text = text[9..]
-      else if text[0] is "<" or text[0...2] is '{{'
-        text = @handleTag text, stack
+  # Takes functions that provide the data so we can lazily collect them
+  onSlash: (getCheckText, getText) ->
+    checkText = getCheckText()
+    if @stringEndsWith checkText, '</'
+      text = getText()
+      if tag = @getNextCloseableTag text
+        return "#{tag.element}>"
+    return null
+
+  getNextCloseableTag: (text) ->
+    unclosedTags = @findUnclosedTags text
+    if nextCloseableTag = unclosedTags.pop()
+      return nextCloseableTag
+    return null
+
+  # When a tag is opened a record of it is added to the stack, when the
+  # corresponding closing tag is found, its record is removed from the stack.
+  #
+  findUnclosedTags: (text, unclosedTags = []) ->
+    unless text == ""
+      if text[0] is "<"
+        text = @handleNextTag text, unclosedTags
+        return @findUnclosedTags text, unclosedTags
       else
-        index = @minIndex(text.indexOf("<"), text.indexOf("{{"))
+        index = text.indexOf("<")
         if !!~index
           text = text.substr index
-        else
-          break
-    stack
+          return @findUnclosedTags text, unclosedTags
+    return unclosedTags
 
-  # Finds the minimum index out of two indexes, taking into account indexes of -1
-  minIndex: (a, b) ->
-    return a if a is b
-    return a if b < 0
-    return b if a < 0
-    return a if a < b
-    return b if b < a
-
-  handleComment: (text) ->
-    ind = text.indexOf '-->'
-    if !!~ind
-      text.substr ind + 3
-    else
-      null
-
-  handleCDATA: (text) ->
-    ind = text.indexOf ']]>'
-    if !!~ind
-      text.substr ind + 3
-    else
-      null
-
-  handleTag: (text, stack) ->
-    if tag = @parse(text)
+  handleNextTag: (text, unclosedTags) ->
+    if tag = @parseNextTag text
       if tag.opening
         # opening tag, possibly empty
-        stack.push {element: tag.element, brackets: tag.brackets} unless @isEmpty(tag.element)
-      # tag
+        unclosedTags.push {element: tag.element, type: tag.type} unless @isEmpty(tag.element)
       else if tag.closing
         # closing tag: find matching opening tag (if one exists)
-        while stack.length
-          currentTag = stack.pop()
-          break if currentTag.element is tag.element and currentTag.brackets is tag.brackets
+        _unclosedTags = unclosedTags.slice()
+        foundMatchingTag = false
+        while unclosedTags.length
+          currentTag = unclosedTags.pop()
+          if currentTag.element is tag.element and currentTag.type is tag.type
+            foundMatchingTag = true
+            break;
+        # If we didn't find a matching tag, we've just eaten through our stack!
+        # We have to revert it
+        if !foundMatchingTag
+          unclosedTags.splice 0, 0, _unclosedTags...
       else if tag.selfClosing
         # self closing tag: ignore it
       else
-        console.error 'There are problems...'
-      text.substr tag.length
+        console.error "This should be impossible..."
+      return text.substr tag.length
     else
       # no match
-      text.substr 1
+      return text.substr 1
 
-  parse: (text) ->
-    if text[0] == '<'
-      return @parseTag(text)
-    if text[0...2] == '{{'
-      return @parseHandlebars(text)
-    return null
-
-  parseHandlebars: (text) ->
-    result = {
-      opening: false
-      closing: false
-      element: ''
-      brackets: '{{'
-    }
-    match = text.match(/\{\{([#\/])([^\s\/>]+)(\s+([\w-:]+?))*?\s*?\}\}/i)
-    if match
-      result.element     = match[2]
-      result.length      = match[0].length
-      result.opening     = if match[1] is '#' then true else false
-      result.closing     = if match[1] is '/' then true else false
-      result.selfClosing = false
-      result
-    else
-      null
-
-  parseTag: (text) ->
+  parseNextTag: (text) ->
     result = {
       opening: false
       closing: false
       selfClosing: false
       element: ''
-      brackets: '<'
+      type: 'xml'
       length: 0
     }
-    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'{](.*?)["'}])?)*\s*(\/)?>/i)
+    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
     if match
       result.element     = match[2]
       result.length      = match[0].length
@@ -151,3 +110,17 @@ module.exports =
 
   isEmpty: (tag) ->
     @emptyTags.indexOf(tag.toLowerCase()) > -1
+
+  # Utils
+
+  # Finds the minimum index out of two indexes, taking into account indexes of -1
+  minIndex: (a, b) ->
+    return a if a is b
+    return a if b < 0
+    return b if a < 0
+    return a if a < b
+    return b if b < a
+
+  # Checks if one string ends in another
+  stringEndsWith: (a, b) ->
+    a.substr(a.length - b.length, a.length) == b

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -12,294 +12,330 @@ describe "LessThanSlash", ->
     workspaceElement = atom.views.getView(atom.workspace)
     activationPromise = atom.packages.activatePackage('less-than-slash')
 
-  describe "isEmpty and emptyTags", ->
-    it "is true when it isEmpty", ->
-      expect(LessThanSlash.isEmpty "br").toBe true
-    it "is false when not isEmpty", ->
-      expect(LessThanSlash.isEmpty "div").toBe false
+  describe "onSlash", ->
+    it "returns the appropriate closing tag", ->
+      getCheckText = ->
+        '<div class="moo"><a href="/cows">More cows!</'
+      getText = ->
+        '<div class="moo"><a href="/cows">More cows!<'
+      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe 'a>'
 
+      getCheckText = ->
+        '<div class="moo"><a href="/cows">More cows!</a></'
+      getText = ->
+        '<div class="moo"><a href="/cows">More cows!</a><'
+      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe 'div>'
 
-  describe "handleComment does its thing", ->
-    it "skips a comment", ->
-      text = "<!-- This is some ipsum --><p>Lorem ipsum...</p>"
-      expect(LessThanSlash.handleComment text).toBe "<p>Lorem ipsum...</p>"
+    it "returns null if there are no tags to close", ->
+      getCheckText = ->
+        '<div class="moo"><a href="/cows">More cows!</a></div></'
+      getText = ->
+        '<div class="moo"><a href="/cows">More cows!</a></div><'
+      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe null
 
-    it "returns nothing if comment at end", ->
-      text = "<!-- This is a comment at the end -->"
-      expect(LessThanSlash.handleComment text).toBe ""
+      getCheckText = ->
+        '</'
+      getText = ->
+        '<'
+      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe null
 
-    it "doesn't have a cow if someone tries to start a second comment", ->
-      text = "<!-- foobar <!-- For some reason someone did this --> -->"
-      expect(LessThanSlash.handleComment text).toBe " -->"
+    it "works around mismatched tags", ->
+      getCheckText = ->
+        '<div class="moo"><a href="/cows">More cows!</i></'
+      getText = ->
+        '<div class="moo"><a href="/cows">More cows!</i><'
+      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe 'a>'
 
-    it "doesn't complete from outside comment", ->
-      text = "<div><!--"
-      expect(LessThanSlash.findTagsIn text).toEqual []
+      getCheckText = ->
+        '<div class="moo"><a href="/cows"><em>More cows!</i></a></'
+      getText = ->
+        '<div class="moo"><a href="/cows"><em>More cows!</i></a><'
+      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe 'div>'
 
-    it "correctly completes around comment", ->
-        text = "<div><!--<span>-->"
-        stack = LessThanSlash.findTagsIn text
-        expect(stack[0].element).toBe "div"
-
-    it "completes within comment", ->
-        text = "<div><!--<span>"
-        stack = LessThanSlash.findTagsIn text
-        expect(stack.length).toBe 1
-        expect(stack[0].element).toBe "span"
-
-    describe "handleCDATA does its thing", ->
-      it "skips a CDATA", ->
-        text = "<![CDATA[This is some ipsum]]><p>Lorem ipsum...</p>"
-        expect(LessThanSlash.handleCDATA text).toBe "<p>Lorem ipsum...</p>"
-
-      it "returns nothing if CDATA at end", ->
-        text = "<![CDATA[This is a CDATA at the end]]>"
-        expect(LessThanSlash.handleCDATA text).toBe ""
-
-      it "doesn't complete from outside CDATA", ->
-        text = "<div><![CDATA["
-        expect(LessThanSlash.findTagsIn text).toEqual []
-
-      it "correctly completes around CDATA", ->
-          text = "<div><![CDATA[<span>]]>"
-          stack = LessThanSlash.findTagsIn text
-          expect(stack[0].element).toBe "div"
-
-      it "completes within CDATA", ->
-          text = "<div><![CDATA[<span>"
-          stack = LessThanSlash.findTagsIn text
-          expect(stack.length).toBe 1
-          expect(stack[0].element).toBe "span"
-
-  describe "parseTag does its thing", ->
-    it "detects an opening tag", ->
+  describe "getNextCloseableTag", ->
+    it "returns the next closeable tag", ->
       text = "<div>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.getNextCloseableTag(text)).toEqual {
+        element: "div",
+        type: "xml"
+      }
+
+      text = "<div><a><br></a><ul><li></li><li></li></ul>"
+      expect(LessThanSlash.getNextCloseableTag(text)).toEqual {
+        element: "div",
+        type: "xml"
+      }
+
+    it "returns null when all tags are closed", ->
+      text = "<div><a></a></div>"
+      expect(LessThanSlash.getNextCloseableTag(text)).toBe null
+
+  describe "findUnclosedTags", ->
+    it "returns a list of unclosed tags", ->
+      text = "<div><a></a><em>"
+      expect(LessThanSlash.findUnclosedTags(text)).toEqual [
+        {
+          element: "div",
+          type: "xml"
+        }
+        {
+          element: "em",
+          type: "xml"
+        }
+      ]
+
+      text = "<div><a></a></div>"
+      expect(LessThanSlash.findUnclosedTags(text)).toEqual []
+
+    it "still works around mismatched tags", ->
+      text = "<div></i><a>"
+      expect(LessThanSlash.findUnclosedTags(text)).toEqual [
+        {
+          element: "div",
+          type: "xml"
+        }
+        {
+          element: "a",
+          type: "xml"
+        }
+      ]
+
+  describe "handleNextTag", ->
+    it "consumes the next tag and places it in the stack", ->
+      text = "<div><a>"
+      unclosedTags = []
+      expect(LessThanSlash.handleNextTag(text, unclosedTags)).toBe "<a>"
+      expect(unclosedTags).toEqual [
+        {
+          element: "div",
+          type: "xml"
+        }
+      ]
+
+    it "consumes the next closing tag and removes it from the stack", ->
+      text = "</a></div>"
+      unclosedTags = [
+        {
+          element: "div",
+          type: "xml"
+        }
+        {
+          element: "a",
+          type: "xml"
+        }
+      ]
+      expect(LessThanSlash.handleNextTag(text, unclosedTags)).toBe "</div>"
+      expect(unclosedTags).toEqual [
+        {
+          element: "div",
+          type: "xml"
+        }
+      ]
+
+    it "discards mismatched tags", ->
+      text = "</em></a></div>"
+      unclosedTags = [
+        {
+          element: "div",
+          type: "xml"
+        }
+        {
+          element: "a",
+          type: "xml"
+        }
+      ]
+      expect(LessThanSlash.handleNextTag(text, unclosedTags)).toBe "</a></div>"
+      expect(unclosedTags).toEqual [
+        {
+          element: "div",
+          type: "xml"
+        }
+        {
+          element: "a",
+          type: "xml"
+        }
+      ]
+
+  describe "parseNextTag", ->
+    it "parses an opening tag", ->
+      text = "<div>"
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'div',
-        brackets: '<'
+        type: 'xml'
         length: 5
       }
 
-    it "detects a closing tag", ->
+    it "parses a closing tag", ->
       text = "</div>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: false
         closing: true
         selfClosing: false
         element: 'div'
-        brackets: '<'
+        type: 'xml'
         length: 6
       }
 
-    it "detects a self closing tag", ->
+    it "parses self closing tags", ->
       text = "<br/>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: false
         closing: false
         selfClosing: true
         element: 'br'
-        brackets: '<'
+        type: 'xml'
         length: 5
       }
 
     it "returns null when there is no tag", ->
       text = "No tag here!"
-      expect(LessThanSlash.parseTag text).toBe null
+      expect(LessThanSlash.parseNextTag text).toBe null
 
-    it "doesn't have a cow when an element has properties", ->
+    it "works around element properties", ->
       text = "<div class=\"container\">"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'div'
-        brackets: '<'
+        type: 'xml'
         length: 23
       }
 
-    it "doesn't have a cow when you use the wrong quotes", ->
+    it "doesn't care which quotes you use", ->
       text = "<div class='container'>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'div'
-        brackets: '<'
+        type: 'xml'
+        length: 23
+      }
+
+      text = "<div class=`container`>"
+      expect(LessThanSlash.parseNextTag text).toEqual {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        type: 'xml'
         length: 23
       }
 
     it "plays nicely with JSX curly brace property values", ->
-      text = "<input type=\"text\"disabled={this.props.isDisabled}/>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      text = "<input type=\"text\" disabled={this.props.isDisabled}/>"
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: false
         closing: false
         selfClosing: true
         element: 'input'
-        brackets: '<'
-        length: 52
+        type: 'xml'
+        length: 53
       }
 
     it "plays nicely with multiline namespaced attributes", ->
       text = "<elem\n ns1:attr1=\"text\"\n  ns2:attr2=\"text\"\n>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'elem'
-        brackets: '<'
+        type: 'xml'
         length: 44
       }
 
-    it "doesn't have a cow when you use retarded spacing", ->
+    it "works around weird spacing", ->
       text = "<div  class=\"container\" \n  foo=\"bar\">"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'div'
-        brackets: '<'
+        type: 'xml'
         length: 37
       }
 
-    it "doesn't have a cow when you use lone properties", ->
+    it "works around lone properties", ->
       text = "<input type=\"text\" required/>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: false
         closing: false
         selfClosing: true
         element: 'input'
-        brackets: '<'
+        type: 'xml'
         length: 29
       }
 
     it "doesn't have a cow when properties contain a '>'", ->
       text = "<p ng-show=\"3 > 5\">Uh oh!"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'p'
-        brackets: '<'
+        type: 'xml'
         length: 19
       }
 
     it "finds the expected tag when tags are nested", ->
       text = "<a><i>"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'a'
-        brackets: '<'
+        type: 'xml'
         length: 3
       }
 
     it "finds the expected tag when tags with attributes are nested", ->
       text = "<a href=\"#\"><i class=\"fa fa-home\">"
-      expect(LessThanSlash.parseTag text).toEqual {
+      expect(LessThanSlash.parseNextTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'a'
-        brackets: '<'
+        type: 'xml'
         length: 12
       }
 
-  describe "handleTag does its thing", ->
-    it "finds an opening tag", ->
-      stack = []
-      text = "<div>"
-      text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ""
-      expect(stack[0].element).toBe "div"
+  describe "isEmpty", ->
+    it "is true when it isEmpty", ->
+      expect(LessThanSlash.isEmpty "br").toBe true
 
-    it "finds a closing tag and pops the stack", ->
-      stack = ["div"]
-      text = "</div>"
-      text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ""
-      expect(stack.length).toBe 0
-
-    it "finds a tag that is in emptyTags and skips it", ->
-      stack = []
-      text = "<input>"
-      text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ""
-      expect(stack.length).toBe 0
-
-    it "finds a self closing tag and skips it", ->
-      stack = []
-      text = "<br/>"
-      text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ""
-      expect(stack.length).toBe 0
-
-    it "doesn't find a tag and returns text, one char advanced", ->
-      stack = []
-      text = "<- this guy"
-      text = LessThanSlash.handleTag text, stack
-      expect(text).toBe "- this guy"
-      expect(stack.length).toBe 0
-
-  describe "findTagsIn does its thing", ->
-    it "finds unmatched tags in markup", ->
-      text = "<div><p><i></i><span>"
-      stack = LessThanSlash.findTagsIn text
-      expect(stack.length).toBe 3
-      expect(stack[0].element).toBe "div"
-      expect(stack[1].element).toBe "p"
-      expect(stack[2].element).toBe "span"
-
-    it "correctly finds nested tags with attributes", ->
-      text = "<a href=\"#\"><i class=\"fa fa-home\">"
-      stack = LessThanSlash.findTagsIn text
-      expect(stack.length).toBe 2
-      expect(stack[0].element).toBe "a"
-      expect(stack[1].element).toBe "i"
-
-  describe "parseHandlebars does its thing", ->
-    it "detects an opening tag", ->
-      text = "{{#if currentUser}}"
-      expect(LessThanSlash.parseHandlebars text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'if',
-        brackets: '{{'
-        length: 19
-      }
-
-    it "detects a closing tag", ->
-      text = "{{/if}}"
-      expect(LessThanSlash.parseHandlebars text).toEqual {
-        opening: false
-        closing: true
-        selfClosing: false
-        element: 'if'
-        brackets: '{{'
-        length: 7
-      }
-
-    it "returns null when there is no tag", ->
-      text = "No tag here!"
-      expect(LessThanSlash.parseHandlebars text).toBe null
+    it "is false when not isEmpty", ->
+      expect(LessThanSlash.isEmpty "div").toBe false
 
   describe "minIndex", ->
     it "returns the lower number", ->
       lower = LessThanSlash.minIndex(3, 5)
       expect(lower).toBe 3
+
       lower = LessThanSlash.minIndex(5, 3)
       expect(lower).toBe 3
 
     it "discards a negative index", ->
       lower = LessThanSlash.minIndex(3, -1)
       expect(lower).toBe 3
+
       lower = LessThanSlash.minIndex(-1, 3)
       expect(lower).toBe 3
 
     it "passes on double negative indicies", ->
       lower = LessThanSlash.minIndex(-1, -1)
       expect(lower).toBe -1
+
+  describe "stringEndsWith", ->
+    it "returns true if the first string ends in the second", ->
+      a = "don't have a cow, man!"
+      b = "man!"
+      expect(LessThanSlash.stringEndsWith(a, b)).toBe true
+
+    it "returns false if the first string does not end in the second", ->
+      a = "chunky bacon"
+      b = "chunky"
+      expect(LessThanSlash.stringEndsWith(a, b)).toBe false


### PR DESCRIPTION
I've rewritten a lot of the package to make it more extensible and maintainable.

Autocompletion is now contained in its own function with no dependency on Atom's buffers or events, this makes it super easy to test behaviour of the whole plugin from jasmine.

Things such as comments and CDATA are now handled as their own type of tag and can be closed by typing `</` just like a regular tag.

`findTagsIn` is now `findUnclosedTags`, It now works recursively instead of through a `while` loop and stores tags as objects so that we can later figure out whether they were originally an xml tag or a comment, for example.

It should also be much easier to add parsing support for more tag variants. The `parseNextTag` function uses the `LessThanSlash.parsers` array to figure out which parser to hand the string to.
